### PR TITLE
Leroyle wisblock

### DIFF
--- a/Heltec-CubeCell-Board/examples/cubecell-helium-us915-basic/console-decoders/sample_decoder.js
+++ b/Heltec-CubeCell-Board/examples/cubecell-helium-us915-basic/console-decoders/sample_decoder.js
@@ -1,0 +1,20 @@
+// Helium console decoder
+// This is a very simple decoder for testing only. modify to suit your
+// payload  needs 
+
+function Decoder(bytes, port) {
+  var custom_msg={};
+
+  try{
+       var result = String.fromCharCode.apply(null, bytes);
+  
+       custom_msg.payload={};
+       custom_msg.payload= bytes;
+       custom_msg.AsString={};
+       custom_msg.AsString = result;
+       return custom_msg;
+  
+  } catch (err) {
+       return 'DecoderError: ' + err.name + " : " + err.message;; 
+  }
+}

--- a/RAKWireless-WisBlock/README.md
+++ b/RAKWireless-WisBlock/README.md
@@ -15,7 +15,7 @@ Recent API changes to the runtime support library, SX126x-Arduino, have resulted
 incompatibilty between version 1.3x and version 2.x. 
 Refer to the README file within the example subdirectory for details.
 ```
-For a complete guide to getting started with PlatformIO and the RAKWireless WisBlock line of developer boards refer to the Helium documentation set at https://docs.helium.com/use-the-network/devices/development/rak-wisblock-starter.
+For a complete guide to getting started with PlatformIO and the RAKWireless WisBlock line of developer boards refer to the Helium documentation set at https://docs.helium.com/use-the-network/devices/development/rakwireless/wisblock-4631/
 
 NOTE: The WisBlock is not currently supported by PlatformIO out of the box. One must follow the guide referenced above when installing VSCode/PlatformIO for WisBlock.
 

--- a/RAKWireless-WisBlock/README.md
+++ b/RAKWireless-WisBlock/README.md
@@ -9,6 +9,12 @@ have multiple combinations of expansion boards added to it. The full WisBlock of
 Here you will find one or more sample PlatformIO embedded projects designed to transmit LoRaWAN packets using a [WisBlock Starter Kit](https://store.rakwireless.com/products/wisblock-starter-kit).
 
 ## Getting Started
+```
+Library update notice:
+Recent API changes to the runtime support library, SX126x-Arduino, have resulted in library version
+incompatibilty between version 1.3x and version 2.x. 
+Refer to the README file within the example subdirectory for details.
+```
 For a complete guide to getting started with PlatformIO and the RAKWireless WisBlock line of developer boards refer to the Helium documentation set at https://docs.helium.com/use-the-network/devices/development/rak-wisblock-starter.
 
 NOTE: The WisBlock is not currently supported by PlatformIO out of the box. One must follow the guide referenced above when installing VSCode/PlatformIO for WisBlock.

--- a/RAKWireless-WisBlock/examples/LoRaWan_OTAA/README.md
+++ b/RAKWireless-WisBlock/examples/LoRaWan_OTAA/README.md
@@ -4,6 +4,34 @@
 Here you will find a very basic example of a WisBlock/Helium embedded project that uses PlatformIO as the development IDE rather than the Arduino IDE.
 This version will join the Helium network and periodically send a "Hello" to the Helium network.
 
+## Support Library Version Incompatibility
+Recent API changes to the runtime support library, SX126x-Arduino, have resulted in library version incompatibility between version 1.3x and version 2.x. The two major changes at the device application level are:
+* The lmh_init() API requires 2 more parameters
+* the device application is no longer required to call Radio.IrqProcess() within it's main processing loop.
+
+The complete details of the version change can be found [here](https://github.com/beegee-tokyo/SX126x-Arduino/blob/master/README_V2.md).
+
+The sample within this directory will support both version 1.3.x and version 2.x of the SX126x-Arduino. The platformio.ini contains the following snippet:
+```
+;; comment out the following if using Version 1.3.x of
+;; the SX126x-Arduino library
+lib_deps = beegee-tokyo/SX126x-Arduino   ; version 2
+
+;; Uncomment the following 2 lines if using Version 1.3.x of
+;; the SX126x-Arduino library
+;lib_deps = beegee-tokyo/SX126x-Arduino@^1.2.1  ; version 1.3.x
+;build_flags = -DREGION_US915 -DSX126x_Arduino_Ver1  ; version 1.3.x
+```
+
+The above is configured to support compiling against version 2.x of the SX126x-Arduino library. 
+
+Based on the value of lib_deps, PlatformIO will download the appropriate library version into the project's .pio/libdeps/wiscore_rak4631 subdirectory. This can be verified by inspecting the library.properties file that is contained within the downloaded library.
+
+The device application's main.cpp file contains the following conditional compile directive with determines which version of API to call.
+```
+#ifdef SX126x_Arduino_Ver1
+``
+
 ### Hardware
 The only hardware required is:
 * the [WisBlock Starter Kit](https://store.rakwireless.com/products/wisblock-starter-kit) containing  the base board with the core module installed.

--- a/RAKWireless-WisBlock/examples/LoRaWan_OTAA/README.md
+++ b/RAKWireless-WisBlock/examples/LoRaWan_OTAA/README.md
@@ -30,7 +30,7 @@ Based on the value of lib_deps, PlatformIO will download the appropriate library
 The device application's main.cpp file contains the following conditional compile directive with determines which version of API to call.
 ```
 #ifdef SX126x_Arduino_Ver1
-``
+```
 
 ### Hardware
 The only hardware required is:

--- a/RAKWireless-WisBlock/examples/LoRaWan_OTAA/console-decoders/sample_decoder.js
+++ b/RAKWireless-WisBlock/examples/LoRaWan_OTAA/console-decoders/sample_decoder.js
@@ -1,0 +1,14 @@
+// Helium console decoder
+// This is a very simple decoder for testing only. modify to suit your
+// payload  needs
+
+function Decoder(bytes, port) {
+  var custom_msg={}; 
+  try{
+      var result = String.fromCharCode.apply(null, bytes);
+      custom_msg.received_payload = result;
+      return custom_msg;
+  } catch (err) {
+      return 'Decoder: ' + err.name + " : " + err.message;; 
+  }
+}

--- a/RAKWireless-WisBlock/examples/LoRaWan_OTAA/platformio.ini
+++ b/RAKWireless-WisBlock/examples/LoRaWan_OTAA/platformio.ini
@@ -8,9 +8,33 @@
 ; Please visit documentation for the other options and examples
 ; https://docs.platformio.org/page/projectconf.html
 
-[env:wiscore_rak4631]
+; uncomment the appropriate line and env section for the version of the
+;  SX126x-Arduino library that you are targeting,
+;  wiscore_rak4631_v1 for version 1
+;  wiscore_rak4631_v2 for version 2
+
+[platformio]
+default_envs = wiscore_rak4631_v2
+;default_envs = wiscore_rak4631_v1
+
+[env:wiscore_rak4631_v2]
 platform = nordicnrf52
 board = wiscore_rak4631
 framework = arduino
-lib_deps = beegee-tokyo/SX126x-Arduino@^1.2.1
-build_flags = -DREGION_US915
+lib_deps = beegee-tokyo/SX126x-Arduino
+;build_type = debug
+; uncomment if using stlink for debugging
+;upload_protocol = stlink
+;debug_tool = stlink
+
+; [env:wiscore_rak4631_v1]
+; platform = nordicnrf52
+; board = wiscore_rak4631
+; framework = arduino
+; lib_deps = beegee-tokyo/SX126x-Arduino@^1.2.1
+; build_flags = -DREGION_US915 -DSX126x_Arduino_Ver1  ; Denotes use V1.2+
+; build_type = debug
+; uncomment if using stlink for debugging
+; upload_protocol = stlink
+; debug_tool = stlink
+

--- a/RAKWireless-WisBlock/examples/LoRaWan_OTAA/src/main.cpp
+++ b/RAKWireless-WisBlock/examples/LoRaWan_OTAA/src/main.cpp
@@ -88,13 +88,17 @@ void setup()
      delay(5000);
 	// Initialize Serial for debug output
 	Serial.begin(115200);
-	while (!Serial)
-	{
-		delay(10);
-	}
+	// this next will cause the app to pause until
+	// you connect the virtual terminal to the comm port
+	// while (!Serial)
+	// {
+	// 	delay(10);
+	// }
 	Serial.println("=====================================");
 	Serial.println("Welcome to RAK4630 LoRaWan!!!");
 	Serial.println("Type: OTAA");
+
+#ifdef SX126x_Arduino_Ver1
 
 #if defined(REGION_AS923)
 	Serial.println("Region: AS923");
@@ -121,6 +125,11 @@ void setup()
 #endif
 	Serial.println("=====================================");
 
+	Serial.println("Built against SX126x-Arduino version 1.x");
+#else
+	Serial.println("Built against SX126x-Arduino version 2.x");
+#endif  // SX126x_Arduino_Ver1
+
 	//creat a user timer to send data to server period
 	uint32_t err_code;
 	err_code = timers_init();
@@ -135,7 +144,13 @@ void setup()
 	lmh_setAppKey(nodeAppKey);
 
 	// Initialize LoRaWan
+#ifdef SX126x_Arduino_Ver1
+	// SX126x-Arduino version 1 API
 	err_code = lmh_init(&lora_callbacks, lora_param_init, doOTAA);
+#else
+	// SX126x-Arduino version 2.x API
+	err_code = lmh_init(&lora_callbacks, lora_param_init, doOTAA, CLASS_A, LORAMAC_REGION_US915);
+#endif
 	if (err_code != 0)
 	{
 		Serial.printf("lmh_init failed - %d\n", err_code);
@@ -150,7 +165,10 @@ void setup()
 void loop()
 {
 	// Handle Radio events
+#ifdef SX126x_Arduino_Ver1
+	// Not needed for SX126x-Arduino version 2.x
 	Radio.IrqProcess();
+#endif
 }
 
 /**@brief LoRa function for handling HasJoined event.

--- a/ST-B-L072Z-LRWAN1/examples/arduino-helium-us915-double-tap/console-decoders/sample_decoder.js
+++ b/ST-B-L072Z-LRWAN1/examples/arduino-helium-us915-double-tap/console-decoders/sample_decoder.js
@@ -1,0 +1,14 @@
+// Helium console decoder
+// This is a very simple decoder for testing only. modify to suit your
+// payload  needs
+
+function Decoder(bytes, port) {
+  var custom_msg={}; 
+  try{
+      var result = String.fromCharCode.apply(null, bytes);
+      custom_msg.received_payload = result;
+      return custom_msg;
+  } catch (err) {
+      return 'Decoder: ' + err.name + " : " + err.message;; 
+  }
+}

--- a/ST-B-L072Z-LRWAN1/examples/arduino-helium-us915-pedometer/console-decoders/sample_decoder.js
+++ b/ST-B-L072Z-LRWAN1/examples/arduino-helium-us915-pedometer/console-decoders/sample_decoder.js
@@ -1,0 +1,14 @@
+// Helium console decoder
+// This is a very simple decoder for testing only. modify to suit your
+// payload  needs
+
+function Decoder(bytes, port) {
+  var custom_msg={}; 
+  try{
+      var result = String.fromCharCode.apply(null, bytes);
+      custom_msg.received_payload = result;
+      return custom_msg;
+  } catch (err) {
+      return 'Decoder: ' + err.name + " : " + err.message;; 
+  }
+}


### PR DESCRIPTION
Updating WisBlock sample to use the V2 RAK runtime library by default, still has provisions for using the V1 library. This is mentioned in the README
- fix a broken link into docs.helium for the detailed howto docs. 
- added very basic console decoder .js for Cubecell, WisBlock, and the STM board,

- TODO's
- need to update the longfi-arduino counter part
- We still need to update the Arduino/PlatformIO how to docs in the docs repo to account for theV1 vs V2 changes.